### PR TITLE
Extend add_scheme helper function

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1769,10 +1769,7 @@
      *     <is_url>
      */
     function add_scheme($url, $scheme = "http://") {
-        if (substr($url, 0, strlen($scheme)) !== $scheme or $scheme === '') {
-            $url = preg_replace('~^([a-z]+://)?([a-z].*)~', $scheme.'${2}', $url);
-        }
-        return $url;
+        return preg_replace('~^([a-z]+://)?(.+)~i', $scheme.'${2}', $url);
     }
 
     /**

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -126,7 +126,7 @@
         foreach($emoji as $key => $value) {
             $text =  str_replace($key, '<span class="emoji">'.$value.'</span>', $text);
         }
-        
+
         return $text;
     }
 
@@ -1754,10 +1754,13 @@
 
     /**
      * Function: add_scheme
-     * Prefixes a URL with a HTTP scheme if none was detected.
+     * Prefixes a URL with a scheme if none was detected.
+     * Replaces the existing scheme if different to $scheme.
+     * Default scheme is http://.
      *
      * Parameters:
      *     $url - The URL to analyse.
+     *     $scheme - The scheme for the URL (optional).
      *
      * Returns:
      *     URL prefixed with scheme.
@@ -1765,8 +1768,11 @@
      * See Also:
      *     <is_url>
      */
-    function add_scheme($url) {
-        return $url = preg_match('~^[a-z][a-z0-9\+\.\-]+:~i', $url) ? $url : "http://".$url ;
+    function add_scheme($url, $scheme = "http://") {
+        if (substr($url, 0, strlen($scheme)) !== $scheme or $scheme === '') {
+            $url = preg_replace('~^([a-z]+://)?([a-z].*)~', $scheme.'${2}', $url);
+        }
+        return $url;
     }
 
     /**


### PR DESCRIPTION
Accept an optional parameter $scheme to set a scheme different than http.
Existing (arbitrary) schemes are overwritten. This _should_ be a good thing, because it downgrades https to http by default, avoiding possible error causes like invalid certs or broken redirections. You have the last word.
Default scheme is http to be backwards compatible.

Fixes call to tumblr API failing to retrieve data when https is provided by the user in the importer.