### PR TITLE
Removed semicolon that prevents load of site after upgrade on line 49

### DIFF
--- a/includes/lib/JSONFeed.php
+++ b/includes/lib/JSONFeed.php
@@ -46,7 +46,7 @@
                 "version"       => "https://jsonfeed.org/version/1",
                 "title"         => strip_tags($title),
                 "home_page_url" => url("/", MainController::current()),
-                "feed_url"      => unfix(self_url());
+                "feed_url"      => unfix(self_url())
             );
 
             if (!empty($subtitle))


### PR DESCRIPTION
Without removing the semicolon, an error will be generated on a blank front page, rendering the blog unusable. Removing this character restores full access.