### PR TITLE
Patch for jpg orientation from photo or uploader

### DIFF
--- a/feathers/photo/photo.php
+++ b/feathers/photo/photo.php
@@ -205,6 +205,6 @@
             }
 
             // replace uploaded file
-            imagejpeg($img, $filepath, 100);
+            imagejpeg($img, $filepath, 90);
         }
     }

--- a/feathers/photo/photo.php
+++ b/feathers/photo/photo.php
@@ -97,11 +97,14 @@
             if (is_url($_POST['option']['source']))
                 $_POST['option']['source'] = add_scheme($_POST['option']['source']);
 
-            if (isset($_FILES['filename']) and upload_tester($_FILES['filename']))
+            if (isset($_FILES['filename']) and upload_tester($_FILES['filename'])) {
                 $filename = upload(
                     $_FILES['filename'],
                     $this->image_extensions()
                 );
+                
+                $this->fix_jpg_orientation($filename);
+            }
 
             return $post->update(
                 values:array(

--- a/feathers/photo/photo.php
+++ b/feathers/photo/photo.php
@@ -55,7 +55,7 @@
                     code:422
                 );
 
-            $this->fix_jpg_orientation($filename);
+            fix_jpg_orientation($filename);
 
             fallback($_POST['title'], "");
             fallback($_POST['caption'], "");
@@ -103,7 +103,7 @@
                     $this->image_extensions()
                 );
                 
-                $this->fix_jpg_orientation($filename);
+                fix_jpg_orientation($filename);
             }
 
             return $post->update(
@@ -177,37 +177,5 @@
 
         private function image_extensions(): array {
             return array("jpg", "jpeg", "png", "gif", "webp", "avif");
-        }
-
-        private function fix_jpg_orientation($filename): void {
-            $filepath = uploaded($filename, false);
-            $image_info = getimagesize($filepath, $source_info);
-            $source_type = $image_info[2];
-
-            // only do it for JPG (because only JPG got EXIF)
-            if ($source_type != IMAGETYPE_JPEG) {
-                return;
-            }
-
-            // from https://www.php.net/manual/en/function.imagecreatefromjpeg.php#112902
-            $img = imagecreatefromjpeg($filepath);
-            $exif = exif_read_data($filepath);
-
-            if ($img && $exif && isset($exif['Orientation'])) {
-                $ort = $exif['Orientation'];
-
-                if ($ort == 6 || $ort == 5)
-                    $img = imagerotate($img, 270, 0);
-                if ($ort == 3 || $ort == 4)
-                    $img = imagerotate($img, 180, 0);
-                if ($ort == 8 || $ort == 7)
-                    $img = imagerotate($img, 90, 0);
-
-                if ($ort == 5 || $ort == 4 || $ort == 7)
-                    imageflip($img, IMG_FLIP_HORIZONTAL);
-            }
-
-            // replace uploaded file
-            imagejpeg($img, $filepath, 90);
         }
     }

--- a/feathers/uploader/uploader.php
+++ b/feathers/uploader/uploader.php
@@ -56,8 +56,8 @@
                 $filenames = array();
 
                 if (is_array($_FILES['filenames']['name'])) {
-                    for ($i = 0; $i < count($_FILES['filenames']['name']); $i++)
-                        $filenames[] = upload(
+                    for ($i = 0; $i < count($_FILES['filenames']['name']); $i++) {
+                        $filename = upload(
                             array(
                                 'name' => $_FILES['filenames']['name'][$i],
                                 'type' => $_FILES['filenames']['type'][$i],
@@ -66,6 +66,11 @@
                                 'size' => $_FILES['filenames']['size'][$i]
                             )
                         );
+
+                        fix_jpg_orientation($filename);
+
+                        $filenames[] = $filename; 
+                    }
                 } else {
                     $filenames[] = upload($_FILES['filenames']);
                 }
@@ -122,8 +127,8 @@
                 $filenames = array();
 
                 if (is_array($_FILES['filenames']['name'])) {
-                    for($i=0; $i < count($_FILES['filenames']['name']); $i++)
-                        $filenames[] = upload(
+                    for($i=0; $i < count($_FILES['filenames']['name']); $i++) {
+                        $filename = upload(
                             array(
                                 'name' => $_FILES['filenames']['name'][$i],
                                 'type' => $_FILES['filenames']['type'][$i],
@@ -132,6 +137,11 @@
                                 'size' => $_FILES['filenames']['size'][$i]
                             )
                         );
+                        
+                        fix_jpg_orientation($filename);
+
+                        $filenames[] = $filename; 
+                    }
                 } else {
                     $filenames[] = upload($_FILES['filenames']);
                 }


### PR DESCRIPTION
When uploading pictures from my mobilephone, chyrp did not respect the EXIF orientation and showed the pictures with the wrong orientation.
This change rotates the uploaded (JPG-) image(s) to the orientation given in the EXIF information.