### PR TITLE
Support less common locale codes

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -361,11 +361,19 @@
                 if ($dirname == "en_US")
                     continue;
 
-                if (preg_match("/^[a-z]{2}(_|-)[a-z]{2}$/i", $dirname))
-                    $locales[] = array(
-                        "code" => $dirname,
-                        "name" => lang_code($dirname)
-                    );
+                if (class_exists("Locale")) {
+                    if (Locale::getDisplayName($dirname) !== false)
+                        $locales[] = array(
+                            "code" => $dirname,
+                            "name" => lang_code($dirname)
+                        );
+                } else {
+                    if (preg_match("/^[a-z]{2,3}((_|-)[a-z]{2,3})*$/i", $dirname))
+                        $locales[] = array(
+                            "code" => $dirname,
+                            "name" => lang_code($dirname)
+                        );
+                }
             }
         }
 


### PR DESCRIPTION
I've started trying to write a Toki Pona localization of Chyrp Lite. Toki Pona's language code is `tok` and it has no associated country, so the locale regex doesn't know what to do with it. 

This PR updates the regex and uses Intl's locale parsing, if available, to check locales for validity.

It works fine, at least when I'm developing on Linux, but untested on Windows.