### PR TITLE
Fix injector behavior for Posts and Pages

### DIFF
--- a/modules/inject/inject.php
+++ b/modules/inject/inject.php
@@ -72,38 +72,46 @@
             $text,
             $post = null
         ): string {
-            if (!preg_match("/<!-- *inject +([^<>]+) *-->/i", $text, $matches))
-                return $text;
-
-            $content = $this->get_content(
-                self::TYPE_MARKUP_POST,
-                $matches[1]
+            preg_match_all(
+                '/<!-- *inject +([^<>]+?) *-->/i',
+                $text,
+                $matches,
+                PREG_SET_ORDER
             );
 
-            return preg_replace(
-                "/<!-- *inject +([^<>]+) *-->/i",
-                $content,
-                $text
-            );
+            foreach ($matches as $match) {
+                $content = $this->get_content(
+                    self::TYPE_MARKUP_POST,
+                    $match[1]
+                );
+
+                $text = str_replace($match[0], $content, $text);
+            }
+
+            return $text;
         }
 
         public function markup_page_text(
             $text,
             $page = null
         ): string {
-            if (!preg_match("/<!-- *inject +([^<>]+) *-->/i", $text, $matches))
-                return $text;
-
-            $content = $this->get_content(
-                self::TYPE_MARKUP_PAGE,
-                $matches[1]
+            preg_match_all(
+                '/<!-- *inject +([^<>]+?) *-->/i',
+                $text,
+                $matches,
+                PREG_SET_ORDER
             );
 
-            return preg_replace(
-                "/<!-- *inject +([^<>]+) *-->/i",
-                $content,
-                $text
-            );
+            foreach ($matches as $match) {
+                $content = $this->get_content(
+                    self::TYPE_MARKUP_PAGE,
+                    $match[1]
+                );
+
+                $text = str_replace($match[0], $content, $text);
+            }
+
+            return $text;
         }
 
         private function get_content(
@@ -125,19 +133,19 @@
 
                 switch ($injector["frequency"]) {
                     case self::FREQUENCY_ONCE:
-                        if ($injector["count"] == 1)
+                        if ($this->counts[$id] == 1)
                             $content.= $injector["payload"];
 
                         break;
 
                     case self::FREQUENCY_ODD:
-                        if ($injector["count"] % 2 == 1)
+                        if ($this->counts[$id] % 2 == 1)
                             $content.= $injector["payload"];
 
                         break;
 
                     case self::FREQUENCY_EVEN:
-                        if ($injector["count"] % 2 == 0)
+                        if ($this->counts[$id] % 2 == 0)
                             $content.= $injector["payload"];
 
                         break;


### PR DESCRIPTION
I found some errors in the injector module. I made the PR against develop as I saw there were already changes to the module, I hope that's OK.

Testing was "Those fixes work on the site I'm building", so not bulletproof.

There were the following problems with the injector module:

1. The counts were wrong. In the `$injector["frequency"]` switch, the check was against `$injector["count"]` instead of `$this->counts`
2. The regular expression was overeager and matched whitespace together with the injector label
3. Replacement was too eager. The first injector found replaced all other injectors