### PR TITLE
Enhance config dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.sublime-project
 *.sublime-workspace
+.idea/
+
 *.DS_Store
+
+compose.override.yaml
+docker-compose.override.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.3-apache
 
-COPY --chown=www-data . /var/www/html/
+ENV CHYRP_STORAGE_DIR="/data"
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -13,21 +13,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN mkdir -p /data/ \
     && chown -R www-data /data \
-    # Setup script
-    && mv /var/www/html/entrypoint.sh / \
-    && chmod u+x /entrypoint.sh \
-    # Use production config for PHP
     && mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" \
-    # Raise upload_max_size to 100M
     && sed -i 's/upload_max_filesize = .*/upload_max_filesize = 100M/' "$PHP_INI_DIR/php.ini" \
-    # Raise post_max_size to 100M
-    && sed -i 's/post_max_size = .*/post_max_size = 100M/' "$PHP_INI_DIR/php.ini"
+    && sed -i 's/post_max_size = .*/post_max_size = 100M/' "$PHP_INI_DIR/php.ini" \
+    && echo "PassEnv CHYRP_STORAGE_DIR" > /etc/apache2/conf-enabled/chyrp-env.conf
 
-USER www-data
+COPY --chown=www-data --exclude=entrypoint.sh . /var/www/html/
+COPY --chown=www-data --chmod=744 entrypoint.sh /
 
 EXPOSE 80/tcp
 
 VOLUME /data
 VOLUME /var/www/html/uploads
 
+USER www-data
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-sync_config() {
-    inotifywait -qme close_write,moved_to,create /var/www/html/includes/ --format '%f' \
-        | while read -r filename; do
-            if [ "$filename" = "config.json.php" ]; then
-                cp /var/www/html/includes/config.json.php /data/config.json.php
-            fi
-        done
-}
-
 upgrade() {
     until curl -Ifso /dev/null http://localhost/upgrade.php; do
         sleep 0.1
@@ -20,15 +11,11 @@ upgrade() {
 }
 
 inc_dir="/var/www/html/includes"
+storage_dir="${CHYRP_STORAGE_DIR:-$inc_dir}"
 have_config="no"
 
-if [[ -f /data/config.json.php ]]; then
-  cp /data/config.json.php "$inc_dir"
-fi
-
-if [[ -f "$inc_dir/config.json.php" ]]; then
+if [[ -f "$storage_dir/config.json.php" ]]; then
   have_config="yes"
-  sync_config &
 fi
 
 if [[ $have_config == "yes" && -f "$inc_dir/install.php" ]]; then

--- a/includes/class/Config.php
+++ b/includes/class/Config.php
@@ -65,7 +65,7 @@
             $security = "<?php header(\"Status: 403\"); exit(\"Access denied.\"); ?>\n";
 
             $contents = @file_get_contents(
-                INCLUDES_DIR.DIR."config.json.php"
+                STORAGE_DIR.DIR."config.json.php"
             );
 
             if ($contents === false)
@@ -96,7 +96,7 @@
             );
 
             return @file_put_contents(
-                INCLUDES_DIR.DIR."config.json.php",
+                STORAGE_DIR.DIR."config.json.php",
                 $contents
             );
         }

--- a/includes/common.php
+++ b/includes/common.php
@@ -96,6 +96,12 @@
     # Absolute path to /includes.
     define('INCLUDES_DIR', MAIN_DIR.DIR."includes");
 
+    # Constant: STORAGE_DIR
+    # Absolute path to the directory that holds configuration data
+    if (!defined('STORAGE_DIR')) {
+        define('STORAGE_DIR', $_SERVER['CHYRP_STORAGE_DIR'] ?? INCLUDES_DIR);
+    }
+
     # Constant: CACHES_DIR
     # Absolute path to /includes/caches.
     define('CACHES_DIR', INCLUDES_DIR.DIR."caches");
@@ -374,7 +380,7 @@
         );
 
     # Exit if the config file is missing.
-    if (!file_exists(INCLUDES_DIR.DIR."config.json.php"))
+    if (!file_exists(STORAGE_DIR.DIR."config.json.php"))
         error(
             __("Service Unavailable"),
             __("This resource cannot respond because it is not configured."),

--- a/install.php
+++ b/install.php
@@ -33,6 +33,7 @@
     define('DIR',                           DIRECTORY_SEPARATOR);
     define('MAIN_DIR',                      dirname(__FILE__));
     define('INCLUDES_DIR',                  MAIN_DIR.DIR."includes");
+    define('STORAGE_DIR',                   $_SERVER['CHYRP_STORAGE_DIR'] ?? INCLUDES_DIR);
     define('CACHES_DIR',                    INCLUDES_DIR.DIR."caches");
     define('MODULES_DIR',                   MAIN_DIR.DIR."modules");
     define('FEATHERS_DIR',                  MAIN_DIR.DIR."feathers");
@@ -129,7 +130,7 @@
     load_translator("chyrp", INCLUDES_DIR.DIR."locale");
 
     # Already installed?
-    if (file_exists(INCLUDES_DIR.DIR."config.json.php"))
+    if (file_exists(STORAGE_DIR.DIR."config.json.php"))
         redirect($config->url);
 
     if (class_exists("PDO")) {
@@ -160,6 +161,11 @@
     if (!is_writable(INCLUDES_DIR))
         alert(
             __("Please CHMOD or CHOWN the <em>includes</em> directory to make it writable.")
+        );
+
+    if (STORAGE_DIR !== INCLUDES_DIR && !is_writable(STORAGE_DIR))
+        alert(
+            __("Please CHMOD or CHOWN the <em>storage</em> directory to make it writable.")
         );
 
     # Test if we can write to CACHES_DIR (needed by some extensions).

--- a/upgrade.php
+++ b/upgrade.php
@@ -33,6 +33,7 @@
     define('DIR',                           DIRECTORY_SEPARATOR);
     define('MAIN_DIR',                      dirname(__FILE__));
     define('INCLUDES_DIR',                  MAIN_DIR.DIR."includes");
+    define('STORAGE_DIR',                   $_SERVER['CHYRP_STORAGE_DIR'] ?? INCLUDES_DIR);
     define('CACHES_DIR',                    INCLUDES_DIR.DIR."caches");
     define('MODULES_DIR',                   MAIN_DIR.DIR."modules");
     define('FEATHERS_DIR',                  MAIN_DIR.DIR."feathers");
@@ -134,6 +135,11 @@
         if (!is_writable(INCLUDES_DIR))
             alert(
                 __("Please CHMOD or CHOWN the <em>includes</em> directory to make it writable.")
+            );
+
+        if (STORAGE_DIR !== INCLUDES_DIR && !is_writable(STORAGE_DIR))
+            alert(
+                    __("Please CHMOD or CHOWN the <em>storage</em> directory to make it writable.")
             );
 
         # Test if we can write to CACHES_DIR (needed by some extensions).


### PR DESCRIPTION
I introduced a new env var `STORAGE_DIR` to point at a directory that can be used to store data outside of the web root.

The only use case right now is to store the `config.json.php` directly in the `/data/` directory in docker and remove the need for the sync function in the docker file.

But it can also be used in standard hosting situations (via `SetEnv` in `.htaccess` for example) to improve security and make updates easier.

I also added some small clean-ups and improvements to the `Dockerfile` and `.gitignore` files.