### PR TITLE
Fix delimiter typo in markdown trait comments

### DIFF
--- a/includes/lib/xenocrat/markdown/inline/CiteTrait.php
+++ b/includes/lib/xenocrat/markdown/inline/CiteTrait.php
@@ -38,7 +38,7 @@ trait CiteTrait
 					# Capture...
 					# any backslash escaped char;
 					# or any char except backslash and delimiter;
-					# or delimeter run longer than opening marker;
+					# or delimiter run longer than opening marker;
 					# or delimiter run shorter than opening marker:
 					((?>(?:\\\\.|[^\\\\_]|\1_+|(?!\1\*)_+)+))
 					# Last char cannot be whitespace.

--- a/includes/lib/xenocrat/markdown/inline/CodeTrait.php
+++ b/includes/lib/xenocrat/markdown/inline/CodeTrait.php
@@ -34,7 +34,7 @@ trait CodeTrait
 					(?!`)
 					# Capture...
 					# any char except delimiter;
-					# or delimeter run longer than opening marker;
+					# or delimiter run longer than opening marker;
 					# or delimiter run shorter than opening marker:
 					((?>(?:[^`]|\1`+|(?!\1)`+)+))
 					# Closing marker:

--- a/includes/lib/xenocrat/markdown/inline/EmphStrongTrait.php
+++ b/includes/lib/xenocrat/markdown/inline/EmphStrongTrait.php
@@ -59,7 +59,7 @@ trait EmphStrongTrait
 				)
 				|| $marker === '_'
 				&& preg_match(
-					# Marker must be preceded by a word break then 0+ delimeters.
+					# Marker must be preceded by a word break then 0+ delimiters.
 					'/(^|\W|\b_+)$/u',
 					$preceding
 				)
@@ -76,7 +76,7 @@ trait EmphStrongTrait
 						# Closing marker: cannot be preceded by whitespace.
 						# Cannot be preceded by Unicode category Zs, Ps, Pi.
 						(?(R)\1|(?<![\s\p{Zs}\p{Ps}\p{Pi}])__
-						# Marker must be followed by 0+ delimeters then a word break.
+						# Marker must be followed by 0+ delimiters then a word break.
 						(?=_*\b))/usx',
 					$markdown,
 					$matches
@@ -126,7 +126,7 @@ trait EmphStrongTrait
 				)
 				|| $marker === '_'
 				&& preg_match(
-					# Marker must be preceded by a word break then 0+ delimeters.
+					# Marker must be preceded by a word break then 0+ delimiters.
 					'/(^|\W|\b_+)$/u',
 					$preceding
 				)
@@ -143,7 +143,7 @@ trait EmphStrongTrait
 						# Closing marker: cannot be preceded by whitespace.
 						# Cannot be preceded by Unicode category Zs, Ps, Pi.
 						(?(R)\1|(?<![\s\p{Zs}\p{Ps}\p{Pi}])_
-						# Marker must be followed by 0+ delimeters then a word break.
+						# Marker must be followed by 0+ delimiters then a word break.
 						(?=_*\b))/usx',
 					$markdown,
 					$matches

--- a/includes/lib/xenocrat/markdown/inline/HighlightTrait.php
+++ b/includes/lib/xenocrat/markdown/inline/HighlightTrait.php
@@ -35,7 +35,7 @@ trait HighlightTrait
 					# Capture...
 					# any backslash escaped char;
 					# or any char except backslash and delimiter;
-					# or delimeter run longer than opening marker;
+					# or delimiter run longer than opening marker;
 					# or delimiter run shorter than opening marker:
 					((?>(?:\\\\.|[^\\\\=]|\1=+|(?!\1)=+)+))
 					# Closing marker:

--- a/includes/lib/xenocrat/markdown/inline/MathTrait.php
+++ b/includes/lib/xenocrat/markdown/inline/MathTrait.php
@@ -34,7 +34,7 @@ trait MathTrait
 					(?!`)
 					# Capture...
 					# any char except delimiter;
-					# or delimeter run that is not closing marker:
+					# or delimiter run that is not closing marker:
 					((?>(?:[^`]|(?!`\$)`+)+))
 					# Closing marker:
 					`\$/sx',

--- a/includes/lib/xenocrat/markdown/inline/StrikeoutTrait.php
+++ b/includes/lib/xenocrat/markdown/inline/StrikeoutTrait.php
@@ -35,7 +35,7 @@ trait StrikeoutTrait
 					# Capture...
 					# any backslash escaped char;
 					# or any char except backslash and delimiter;
-					# or delimeter run longer than opening marker;
+					# or delimiter run longer than opening marker;
 					# or delimiter run shorter than opening marker:
 					((?>(?:\\\\.|[^\\\\~]|\1~+|(?!\1)~+)+))
 					# Closing marker:

--- a/includes/lib/xenocrat/markdown/inline/SupSubTrait.php
+++ b/includes/lib/xenocrat/markdown/inline/SupSubTrait.php
@@ -35,7 +35,7 @@ trait SupSubTrait
 					# Capture...
 					# any backslash escaped char;
 					# or any char except backslash and delimiter;
-					# or delimeter run longer than opening marker;
+					# or delimiter run longer than opening marker;
 					# or delimiter run shorter than opening marker:
 					((?>(?:\\\\.|[^\\\\+]|\1\++|(?!\1)\++)+))
 					# Closing marker:
@@ -108,7 +108,7 @@ trait SupSubTrait
 					# Capture...
 					# any backslash escaped char;
 					# or any char except backslash and delimiter;
-					# or delimeter run longer than opening marker;
+					# or delimiter run longer than opening marker;
 					# or delimiter run shorter than opening marker:
 					((?>(?:\\\\.|[^\\\\\-]|\1-+|(?!\1)-+)+))
 					# Closing marker:


### PR DESCRIPTION
Typo in code comments across the markdown inline traits: `delimeter` -> `delimiter` (11 instances in 7 files).

The correct spelling is already used in the same files, so this just makes them consistent. Comments only, no functional change.
